### PR TITLE
Swivelmap callback

### DIFF
--- a/src/Swivel/Bucket.js
+++ b/src/Swivel/Bucket.js
@@ -2,9 +2,10 @@
 /**
  * Bucket constructor
  */
-var Bucket = function Bucket(featureMap, index) {
+var Bucket = function Bucket(featureMap, index, callback) {
     this.featureMap = featureMap;
     this.index = index;
+    this.callback = typeof callback === 'function' ? callback : function() {};
 };
 
 /**
@@ -14,5 +15,9 @@ var Bucket = function Bucket(featureMap, index) {
  * @return boolean
  */
 Bucket.prototype.enabled = function enabled(behavior) {
-    return this.featureMap.enabled(behavior.slug, this.index);
+    var slug = behavior.slug;
+    if (!this.featureMap.slugExists(slug)) {
+        this.callback(slug);
+    }
+    return this.featureMap.enabled(slug, this.index);
 };

--- a/src/Swivel/FeatureMap.js
+++ b/src/Swivel/FeatureMap.js
@@ -124,11 +124,25 @@ FeatureMapPrototype.enabled = function enabled(slug, index) {
     for (; i < length; i++) {
         child = list[i];
         key += key ? DELIMITER + child : child;
-        if (!map[key] || !(map[key] & index)) {
+
+        var isMissing = !this.slugExists(key);
+        var isDisabled = isMissing || !(map[key] & index);
+
+        if (isMissing || isDisabled) {
             return false;
         }
     }
     return true;
+};
+
+/**
+ * Check if a feature slug exists in the Map.
+ *
+ * @param String slug
+ * @return Boolean
+ */
+FeatureMapPrototype.slugExists = function slugExists(slug) {
+    return typeof this.map[slug] !== 'undefined';
 };
 
 /**

--- a/test/spec/Bucket.spec.js
+++ b/test/spec/Bucket.spec.js
@@ -20,6 +20,25 @@
                 expect(bucket.enabled(behavior)).toBe(true);
                 expect(featureMap.enabled).toHaveBeenCalledWith("Test.version", 6);
             });
+            it("should equal the slug sent in the callback", function() {
+                var slug = "InvalidSlug";
+                var mapArray = {
+                    "Test" : [1],
+                    "Test.version" : [1],
+                    "Test.version.a" : [1]
+                };
+
+                var map = new FeatureMap(mapArray);
+                var behavior = new Behavior(slug, function() {});
+
+                var bucket = new Bucket(map, 1, function (slugParam) {
+                    expect(slug).toEqual(slugParam);
+                });
+
+                spyOn(map, "enabled").and.callThrough();
+                expect(bucket.enabled(behavior)).toBe(false);
+                expect(map.enabled).toHaveBeenCalledWith(slug, 1);
+            });
         });
     });
 }());

--- a/test/spec/FeatureMap.spec.js
+++ b/test/spec/FeatureMap.spec.js
@@ -123,6 +123,13 @@
                 expect(map6.enabled("Test.version.a", 5)).toBe(false);
             });
         });
+        describe("slugExists", function() {
+            it("should return correct results", function() {
+                var map = new FeatureMap({ a : [1] });
+                expect(map.slugExists("a")).toBe(true);
+                expect(map.slugExists("b")).toBe(false);
+            });
+        });
         describe("intersect", function() {
             it("should find the intersection between two maps and return a new map", function() {
                 var map1 = new FeatureMap({ a : [1,2,3], b : [4,5,6] });


### PR DESCRIPTION
Based on [this PR](https://github.com/zumba/swiveljs/pull/11) so it needs to be merged first.
Ports the same functionality from [this PR](https://github.com/zumba/swivel/pull/30) into the SwivelJS library.
Added optional callback to `Swivel/Bucket` as well as the `slugExists` method to `Swivel/FeatureMap`.

- [x] Merge https://github.com/zumba/swiveljs/pull/11
- [x] Merge this PR
- [ ] Merge [DIST PR](https://github.com/zumba/swiveljs/pull/15)
