### PR TITLE
Constructor callback

### DIFF
--- a/src/Swivel/Builder.js
+++ b/src/Swivel/Builder.js
@@ -136,7 +136,8 @@ BuilderPrototype.getBehavior = function getBehavior(slug, strategy) {
     if (typeof strategy !== 'function') {
         throw 'Invalid callable passed to Builder.getBehavior().';
     }
-    return new Behavior(this.slug + DELIMITER + slug, strategy);
+    slug = !slug ? this.slug : this.slug + DELIMITER + slug;
+    return new Behavior(slug, strategy);
 };
 
 /**

--- a/src/Swivel/Swivel.js
+++ b/src/Swivel/Swivel.js
@@ -10,8 +10,9 @@ var Swivel = function Swivel(config) {
         config = {};
     }
     var map = config.map || {};
+    var callback = config.callback || function() {};
     var featureMap = map instanceof FeatureMap ? map : new FeatureMap(map);
-    this.bucket = new Bucket(featureMap, config.bucketIndex);
+    this.bucket = new Bucket(featureMap, config.bucketIndex, callback);
 };
 
 /**

--- a/test/spec/Builder.spec.js
+++ b/test/spec/Builder.spec.js
@@ -135,6 +135,13 @@
                 expect(behavior instanceof Behavior).toBe(true);
                 expect(behavior.execute()).toBe(0);
             });
+            it("should return behavior with builder slug regardless of getBehavior callback", function() {
+                var builder = new Builder("Test", {});
+                var behavior = builder.getBehavior("", function() { return "notTest"; });
+
+                expect(behavior instanceof Behavior).toBe(true);
+                expect(behavior.slug).toBe("Test");
+            });
         });
     });
 }());

--- a/test/spec/Swivel.spec.js
+++ b/test/spec/Swivel.spec.js
@@ -18,6 +18,18 @@
                 expect(Swivel() instanceof Swivel).toBe(true);
                 /* jshint newcap: true */
             });
+            it("should have a bucket with an empty callback function", function() {
+                var swivel = new Swivel({
+                    callback : function () {
+                        return "Test";
+                    }
+                });
+                expect(swivel.bucket.callback()).toBe("Test");
+            });
+            it("should have a bucket with a valid callback function", function() {
+                var swivel = new Swivel();
+                expect(swivel.bucket.callback()).toBe(undefined);
+            });
         });
         describe("returnValue", function() {
             it("should equal to default value", function() {


### PR DESCRIPTION
Based on [this PR](https://github.com/zumba/swiveljs/pull/12) so it needs to be merged first.
Ports the same functionality from [this PR](https://github.com/zumba/swivel/pull/31) into the SwivelJS library.
Modified `Swivel/Swivel` class to be able to inject the callback into the `Swivel/Bucket` object via the config object.

- [x] Merge https://github.com/zumba/swiveljs/pull/11
- [x] Merge https://github.com/zumba/swiveljs/pull/12
- [ ] Merge [DIST PR](https://github.com/zumba/swiveljs/pull/15)
- [x] Merge this PR