### PR TITLE
Cast to Integer

### DIFF
--- a/src/Swivel/FeatureMap.js
+++ b/src/Swivel/FeatureMap.js
@@ -1,11 +1,14 @@
 /**
- * Used by reduceToBitmask
+ * Used by parse reducer
  *
  * @param Number mask
  * @param Number index
  * @return Number
  */
 var bitmaskIterator = function bitmaskIterator(mask, index) {
+    if (!index || parseInt(index, 10) === 0) {
+        return mask;
+    }
     return mask | 1 << --index;
 };
 
@@ -126,7 +129,7 @@ FeatureMapPrototype.enabled = function enabled(slug, index) {
         key += key ? DELIMITER + child : child;
 
         var isMissing = !this.slugExists(key);
-        var isDisabled = isMissing || !(map[key] & index);
+        var isDisabled = isMissing || !(parseInt(map[key], 10) & index);
 
         if (isMissing || isDisabled) {
             return false;

--- a/test/spec/FeatureMap.spec.js
+++ b/test/spec/FeatureMap.spec.js
@@ -14,6 +14,18 @@
                 var parsed = (new FeatureMap(map)).map;
                 expect(parsed.a).toBe(32 | 64);
                 expect(parsed["a.b"]).toBe(64);
+
+                map = { a :  [""] };
+                parsed = (new FeatureMap(map)).map;
+                expect(parsed.a).toBe(0);
+
+                map = { a :  [0] };
+                parsed = (new FeatureMap(map)).map;
+                expect(parsed.a).toBe(0);
+
+                map = { a :  [0, 1] };
+                parsed = (new FeatureMap(map)).map;
+                expect(parsed.a).toBe(1);
             });
         });
         describe("add", function() {
@@ -71,6 +83,13 @@
         });
         describe("enabled", function() {
             it("should compare the slug to the map and indicate if the feature is enabled", function() {
+                var map0 = new FeatureMap({
+                    "Test" : [], "Test.version" : [], "Test.version.a" : [0]
+                });
+                expect(map0.enabled("Test", 1)).toBe(false);
+                expect(map0.enabled("Test.version", 1)).toBe(false);
+                expect(map0.enabled("Test.version.a", 1)).toBe(false);
+
                 var map1 = new FeatureMap({
                     "Test" : [1], "Test.version" : [1], "Test.version.a" : [1]
                 });


### PR DESCRIPTION
This is to prevent the possibility of a negative bit shift, similar to these:
https://github.com/zumba/swivel/pull/39
https://github.com/zumba/swivel/pull/36