### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,6 +25,8 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Potential fix for [https://github.com/zumba/swiveljs/security/code-scanning/3](https://github.com/zumba/swiveljs/security/code-scanning/3)

In general, fix this by explicitly declaring `permissions` either at the workflow root (applying to all jobs) or for the specific job flagged, and restricting them to the minimal required scope (typically `contents: read` if `GITHUB_TOKEN` is not used to write anything).

For this workflow, the smallest change that addresses the warning without altering behavior is to add a `permissions` block to the `publish-npm` job similar to `publish-gpr`, but limited to read-only since it does not need to write via `GITHUB_TOKEN`. The `build` job might also not need write permissions, but CodeQL has specifically highlighted `publish-npm` (line 26), so we will add:

```yaml
    permissions:
      contents: read
```

just under `runs-on: ubuntu-latest` for the `publish-npm` job. No additional imports or methods are needed, since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
