### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]


### PR DESCRIPTION
Potential fix for [https://github.com/zumba/swiveljs/security/code-scanning/2](https://github.com/zumba/swiveljs/security/code-scanning/2)

In general, the fix is to explicitly define a minimal `permissions:` block for any job that currently relies on default `GITHUB_TOKEN` permissions. For a build/test job that does not need to write to the repository or interact with GitHub entities, `contents: read` is typically sufficient and matches the recommendation from CodeQL.

Specifically, in `.github/workflows/npm-publish.yml`, add a `permissions:` section under the `build` job (lines 11–23). This should mirror the minimal pattern already used in `publish-npm`, setting `contents: read`. No changes are needed to `publish-npm` or `publish-gpr`, as they already define appropriate permissions. No imports or additional methods are required since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
