### PR TITLE
chore: configure Dependabot with assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  assignees:
+  - young-steveo
+  - jrbasso
+  open-pull-requests-limit: 10
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+  assignees:
+  - young-steveo
+  - jrbasso
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## What this PR does

This PR configures Dependabot for this repository.

- Adds/updates `.github/dependabot.yml`
- Assigns PRs to the designated team lead(s)

> Auto-generated by the Dependabot setup script.
